### PR TITLE
std::void_t only supports a single template argument

### DIFF
--- a/include/std/type_traits.h
+++ b/include/std/type_traits.h
@@ -462,7 +462,7 @@ struct invoke_result;
 template<typename Functor, typename... Arguments>
 using invoke_result_t = typename invoke_result<Functor, Arguments...>::type;
 
-template<typename T>
+template<typename...>
 using void_t = void;
 
 } // namespace Type_Traits_Miscellaneous_Transformations


### PR DESCRIPTION
Resolves #69.