### PR TITLE
Fix std::is_convertible for the case where From and To are the same non-copyable type

### DIFF
--- a/include/std/type_traits.h
+++ b/include/std/type_traits.h
@@ -1023,6 +1023,7 @@ template<typename From, typename To>
 struct is_convertible :
     disjunction<
         conjunction<is_void<From>, is_void<To>>,
+        is_same<From, To>,
         conjunction<decltype( Implementation::is_returnable<To>( 0 ) ), decltype( Implementation::is_convertible<From, To>( 0 ) )>> {
 };
 


### PR DESCRIPTION
Resolves #88 (Fix std::is_convertible for the case where From and To are the same non-copyable type).

std::is_convertible<From, To> previously evaluated to std::false_type if
From and To were the same non-copyable type. Having
std::is_convertible<From, To> evaluate to std::true_type if
std::is_same<From, To> evaluates to std::true_type fixes this, but does
assume that the type is move or copy constructible which may not be the
case.