### PR TITLE
Update submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,4 +29,4 @@
 # lizard
 [submodule "lizard"]
 	path = lizard
-	url = ../terryyin-lizard
+	url = ../lizard


### PR DESCRIPTION
Resolves #90.

The lizard submodule URL pointed to a "mirror" (terryyin-lizard) instead
of a fork (lizard).