### PR TITLE
Add cstdint type aliases and supporting macros for 24-bit integer types

### DIFF
--- a/include/std/cstdint.h
+++ b/include/std/cstdint.h
@@ -31,16 +31,19 @@ using ::int16_t;
 using ::int32_t;
 using ::int64_t;
 using ::int8_t;
+using int24_t = ::__int24;
 
 using ::int_fast16_t;
 using ::int_fast32_t;
 using ::int_fast64_t;
 using ::int_fast8_t;
+using int_fast24_t = ::__int24;
 
 using ::int_least16_t;
 using ::int_least32_t;
 using ::int_least64_t;
 using ::int_least8_t;
+using int_least24_t = ::__int24;
 
 using ::intmax_t;
 
@@ -50,20 +53,35 @@ using ::uint16_t;
 using ::uint32_t;
 using ::uint64_t;
 using ::uint8_t;
+using uint24_t = ::__uint24;
 
 using ::uint_fast16_t;
 using ::uint_fast32_t;
 using ::uint_fast64_t;
 using ::uint_fast8_t;
+using uint_fast24_t = ::__uint24;
 
 using ::uint_least16_t;
 using ::uint_least32_t;
 using ::uint_least64_t;
 using ::uint_least8_t;
+using uint_least24_t = ::__uint24;
 
 using ::uintmax_t;
 
 using ::uintptr_t;
+
+#define INT24_MIN       __INT24_MIN__
+#define INT_FAST24_MIN  __INT24_MIN__
+#define INT_LEAST24_MIN __INT24_MIN__
+
+#define INT24_MAX       __INT24_MAX__
+#define INT_FAST24_MAX  __INT24_MAX__
+#define INT_LEAST24_MAX __INT24_MAX__
+
+#define UINT24_MAX       __UINT24_MAX__
+#define UINT_FAST24_MAX  __UINT24_MAX__
+#define UINT_LEAST24_MAX __UINT24_MAX__
 
 } // namespace std
 


### PR DESCRIPTION
Resolves #127 (Add cstdint type aliases and supporting macros for 24-bit
integer types).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
