### PR TITLE
Add megaAVR 0-series SFR macro suppression

### DIFF
--- a/include/avr-libcpp/suppress_sfr_macros.h
+++ b/include/avr-libcpp/suppress_sfr_macros.h
@@ -25,6 +25,6 @@
 
 #include "avr-libcpp/suppress_sfr_macros/atmega2560.h"
 #include "avr-libcpp/suppress_sfr_macros/atmega328p.h"
-#include "avr-libcpp/suppress_sfr_macros/atmega4809.h"
+#include "avr-libcpp/suppress_sfr_macros/megaavr_0_series.h"
 
 #endif // AVRLIBCPP_SUPPRESS_SFR_MACROS_H

--- a/include/avr-libcpp/suppress_sfr_macros/megaavr_0_series.h
+++ b/include/avr-libcpp/suppress_sfr_macros/megaavr_0_series.h
@@ -17,15 +17,18 @@
 
 /**
  * \file
- * \brief avr-libcpp/suppress_sfr_macros/atmega4809 interface.
+ * \brief avr-libcpp/suppress_sfr_macros/megaavr_0_series interface.
  */
 
-#ifndef AVRLIBCPP_SUPPRESS_SFR_MACROS_ATMEGA4809_H
-#define AVRLIBCPP_SUPPRESS_SFR_MACROS_ATMEGA4809_H
+#ifndef AVRLIBCPP_SUPPRESS_SFR_MACROS_MEGAAVR_0_SERIES_H
+#define AVRLIBCPP_SUPPRESS_SFR_MACROS_MEGAAVR_0_SERIES_H
 
 #include <avr/io.h>
 
-#ifdef __AVR_ATmega4809__
+#if defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ )      \
+    || defined( __AVR_ATmega1608__ ) || defined( __AVR_ATmega1609__ ) \
+    || defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) \
+    || defined( __AVR_ATmega4808__ ) || defined( __AVR_ATmega4809__ )
 #ifdef AVRLIBCPP_SUPPRESS_SFR_MACROS
 
 #ifdef AC0
@@ -349,6 +352,7 @@
 #endif // WDT
 
 #endif // AVRLIBCPP_SUPPRESS_SFR_MACROS
-#endif // __AVR_ATmega4809__
+#endif // defined( __AVR_ATmega808__ ) || defined( __AVR_ATmega809__ ) || defined( __AVR_ATmega1608__
+       // ) || defined( __AVR_ATmega1609__ ) || defined( __AVR_ATmega3208__ ) || defined( __AVR_ATmega3209__ ) || defined( __AVR_ATmega4808__ ) || defined( __AVR_ATmega4809__ )
 
-#endif // AVRLIBCPP_SUPPRESS_SFR_MACROS_ATMEGA4809_H
+#endif // AVRLIBCPP_SUPPRESS_SFR_MACROS_MEGAAVR_0_SERIES_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(
     "avr-libcpp/suppress_sfr_macros.cc"
     "avr-libcpp/suppress_sfr_macros/atmega2560.cc"
     "avr-libcpp/suppress_sfr_macros/atmega328p.cc"
-    "avr-libcpp/suppress_sfr_macros/atmega4809.cc"
+    "avr-libcpp/suppress_sfr_macros/megaavr_0_series.cc"
     "avr-libcpp/wdt.cc"
     "climits.cc"
     "cmath.cc"

--- a/source/avr-libcpp/suppress_sfr_macros/megaavr_0_series.cc
+++ b/source/avr-libcpp/suppress_sfr_macros/megaavr_0_series.cc
@@ -17,7 +17,7 @@
 
 /**
  * \file
- * \brief avr-libcpp/suppress_sfr_macros/atmega4809 implementation.
+ * \brief avr-libcpp/suppress_sfr_macros/megaavr_0_series implementation.
  */
 
-#include "avr-libcpp/suppress_sfr_macros/atmega4809.h"
+#include "avr-libcpp/suppress_sfr_macros/megaavr_0_series.h"


### PR DESCRIPTION
Resolves #132 (Add megaAVR 0-series SFR macro suppression).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
