### PR TITLE
Add ATmega3209 build verification

### DIFF
--- a/configuration/atmega3209/CMakeLists.txt
+++ b/configuration/atmega3209/CMakeLists.txt
@@ -1,0 +1,34 @@
+# avr-libcpp
+#
+# Copyright 2020-2021, Andrew Countryman <apcountryman@gmail.com> and the avr-libcpp
+# contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: configuration/atmega3209/CMakeLists.txt
+# Description: avr-libcpp ATmega3209 configuration.
+
+# install prefix is not applicable
+mark_as_advanced( CMAKE_INSTALL_PREFIX )
+
+# build configuration
+set( AVRLIBCPP_MCU                            "atmega3209" CACHE STRING "" FORCE )
+set( AVRLIBCPP_USE_PARENT_PROJECT_BUILD_FLAGS OFF          CACHE BOOL   "" FORCE )
+set( AVRLIBCPP_SUPPRESS_SFR_MACROS            OFF          CACHE BOOL   "" FORCE )
+set( CMAKE_BUILD_TYPE                         "MinSizeRel" CACHE STRING "" FORCE )
+set( CMAKE_EXPORT_COMPILE_COMMANDS            ON           CACHE BOOL   "" FORCE )
+mark_as_advanced(
+    AVRLIBCPP_MCU
+    AVRLIBCPP_USE_PARENT_PROJECT_BUILD_FLAGS
+    AVRLIBCPP_SUPPRESS_SFR_MACROS
+    CMAKE_BUILD_TYPE
+    CMAKE_EXPORT_COMPILE_COMMANDS
+)

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -217,6 +217,14 @@ function ensure_no_atmega3208_build_errors_are_present()
     ensure_no_build_errors_are_present "$build_type" "$ellipsis"
 }
 
+function ensure_no_atmega3209_build_errors_are_present()
+{
+    local -r build_type="atmega3209"
+    local -r ellipsis="............"
+
+    ensure_no_build_errors_are_present "$build_type" "$ellipsis"
+}
+
 function ensure_no_atmega4809_build_errors_are_present()
 {
     local -r build_type="atmega4809"
@@ -287,6 +295,7 @@ function main()
     ensure_no_atmega1608_build_errors_are_present
     ensure_no_atmega1609_build_errors_are_present
     ensure_no_atmega3208_build_errors_are_present
+    ensure_no_atmega3209_build_errors_are_present
     ensure_no_atmega4809_build_errors_are_present
 }
 


### PR DESCRIPTION
Resolves #138 (Add ATmega3209 build verification).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
