### PR TITLE
Fix std::initializer_list::end() compilation error

### DIFF
--- a/include/std/initializer_list.h
+++ b/include/std/initializer_list.h
@@ -56,7 +56,7 @@ class initializer_list {
 
     constexpr auto end() const noexcept -> const_iterator
     {
-        return m_begin + size;
+        return m_begin + m_size;
     }
 
   private:


### PR DESCRIPTION
Resolves #192 (Fix std::initializer_list::end() compilation error).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
